### PR TITLE
Correct what I think is a wrong variable name used in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ function taxonomy_meta_initiate() {
 	/**
 	 * Instantiate our taxonomy meta object
 	 */
-	new Taxonomy_MetaData( 'category', $fields, $title, $overrides );
+	new Taxonomy_MetaData( 'category', $fields, $title, $wlo_overrides );
 }
 taxonomy_meta_initiate();
 ```


### PR DESCRIPTION
Hi there :),

Using this plugin, and I think I spotted an error with `$overrides` being used instead of `$wlo_overrides`. Corrected it.